### PR TITLE
Fix login form input length

### DIFF
--- a/app/templates/seller/login.html
+++ b/app/templates/seller/login.html
@@ -20,7 +20,7 @@
                 <br>
                 {{ form.hidden_tag() }}
                     {% for field in form if field.widget.input_type != 'hidden' %}
-                        <p>
+                        <p class="login-inputs">
                             {{ field.label }}
                             <br>
                             {{  field }}

--- a/static/style.css
+++ b/static/style.css
@@ -34,11 +34,11 @@ html {
 	}
 }
 
-label,
-input {
+.login-inputs {
 	width: 400px;
 	height: 40px;
 }
+
 #big-logo {
 	margin-bottom: 30px;
 	max-width: 100%;


### PR DESCRIPTION
**What does this PR do?**
- This pull request fixes the height and width of the seller login inputs

**Description of the task to be completed** 
- Add a class to the login form inputs' `<p>` wrappers
- Use that class to give the inputs a width of 400 px  and a height of 40px in `static/style.css`

**How should this  be tested**
- None