### PR TITLE
Sellers can edit products

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,3 +60,24 @@ def add_product():
     db.session.add(new_product)
     db.session.commit()
     return redirect('/products') 
+
+@app.route('/products/<id>', methods=['GET'])
+def get_product(id):
+    if ("seller_email" not in session):
+        return redirect('/login')
+    product = Product.query.get_or_404(id)
+    return render_template('seller/product.html', prod = product)
+
+
+@app.route('/products/<id>', methods=['POST'])
+def update_product(id):
+    if ("seller_email" not in session):
+        return redirect('/login')
+    product = Product.query.get_or_404(id)
+    product.name = request.form['product_name']
+    product.price = request.form['product_price']
+    product.image_url = request.form['product_image']
+    product.category = request.form['product_selling_status']
+    db.session.add(product)
+    db.session.commit()
+    return redirect(f'/products/{id}')

--- a/app/templates/seller/product.html
+++ b/app/templates/seller/product.html
@@ -1,0 +1,71 @@
+{% extends 'seller/seller_base.html' %}
+
+{% block title %}{{prod.name}}{% endblock %}
+
+{% block content %}
+<div class="row container-fluid">
+    <div class="col-md-2 d-lg-none"></div>
+    <div class="mb-3 mb-4 view-product col-xs-12 col-sm-12 col-md-8 col-lg-6 col-xl-5">
+        <div class="p-3 m-3 view-product-container border rounded shadow-lg">
+            <div class="row">
+                <div class="col-sm-12 d-flex justify-content-center">
+                    <div>
+                    <center><h2 class="p-3">{{prod.name}}</h2></center>
+                    </div>
+                </div>
+                <div class="col-sm-12 d-flex justify-content-center">
+                    <div>
+                    <img src="{{prod.image_url}}" height="250" width="250">
+                    </div>
+                </div>
+                <div class="col-12 d-flex justify-content-center">
+                    <h3 class="mt-3">${{prod.price}}</h3><a class="mt-3 mx-3 btn btn-md btn-primary text-white" href="#">Buy</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2 d-lg-none"></div>
+    <div class="edit-product col-xs-12 col-sm-12 col-md-12 col-lg-6 col-xl-7">
+        <div class="row">
+            <div class="col-12 p-3 edit-product-container border rounded shadow-lg">
+            <center><h2>Edit Product</h2></center>
+            <form method="POST" action="/products/{{prod.id}}">
+                <div class="row">
+                    <div class="form-group col-6">
+                        <label for="product-name">Name</label>
+                        <input type="text" name="product_name" class="form-control" id="product-name" required value="{{prod.name}}">
+                    </div>
+                    <div class="form-group col-6">
+                        <label for="product-image">Image</label>
+                        <input type="text" name="product_image" class="form-control" id="product-image" required value="{{prod.image_url}}">
+                    </div>
+                </div>
+                <br>
+                <div class="row">
+                    <div class="form-group col-6">
+                        <label for="product-price">Price</label>
+                        <input type="float" name="product_price" id="product-price" class="form-control" value={{prod.price}} required>
+                    </div>
+                    <div class="form-group col-6">
+                        <label for="product-selling-status">Selling Status</label>
+                        <select id="product-selling-status" name="product_selling_status" class="form-control" required>
+                            <option>Choose...</option>
+                            {% if prod.category=="Selling" %}
+                            <option selected>Selling</option>
+                            {% else %}
+                            <option>Selling</option>
+                            {% endif %}
+                            {% if prod.category == "Not Selling" %}
+                            <option selected>Not Selling</option>
+                            {% else %}
+                            <option>Not Selling</option>
+                            {% endif %}
+                        </select>
+                    </div>
+                </div>
+                <br>
+                <button type="submit" class="btn btn-primary">Save</button>
+            </form>
+            </div>
+</div>
+{% endblock %} 

--- a/app/templates/seller/products.html
+++ b/app/templates/seller/products.html
@@ -50,7 +50,7 @@
                   </thead>
             {% for prod in products %}
             <tbody>
-                  <tr>
+                  <tr class="table-row" data-id="{{prod.id}}">
                     <td>{{prod.name}}</td>
                     <td><img src="{{prod.image_url}}" class="prod-img"></img></td>
                     <td>{{prod.price}}</td>

--- a/app/templates/seller/seller_base.html
+++ b/app/templates/seller/seller_base.html
@@ -31,6 +31,7 @@
     </nav>
     {% block content %}{% endblock %}
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="../../../static/script.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,10 @@
+$('.table-row').click(function(evt) {
+	let firstParent = $(evt.target).parent();
+	let id = 0;
+	if (typeof $(firstParent).data().id === 'number') {
+		id = $(firstParent).data().id;
+	} else {
+		id = $(firstParent).parent().data().id;
+	}
+	window.location.href = `/products/${id}`;
+});

--- a/static/style.css
+++ b/static/style.css
@@ -88,3 +88,29 @@ body {
 	width: 100px;
 	height: 100px;
 }
+
+.table-row:hover {
+	background: #eceff1;
+}
+
+.prod-big-img {
+	width: 300px;
+	height: 300px;
+}
+
+.view-product {
+	height: 100%;
+}
+.edit-product {
+	height: 100%;
+}
+
+.edit-product-container,
+.view-product-container {
+	display: flex-inline;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background-color: white;
+	margin: 20px;
+}

--- a/tests/test_seller_routes.py
+++ b/tests/test_seller_routes.py
@@ -93,3 +93,35 @@ class SellerRoutesTestCase(TestCase):
             self.assertIn('5.99', resp.get_data(as_text=True))
             self.assertIn('https://scontent-ort2-2.xx.fbcdn.net/v/t1.0-9/16571', resp.get_data(as_text=True))
             self.assertIn('Not Selling', resp.get_data(as_text=True))  
+
+    def test_updating_products(self):
+        with self.client as client:
+            # test going to a product with seller_email not in the session
+            client.get('/logout')
+            resp = client.get('/products/1', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+
+            # test going to a product page with seller_email in the session
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.get('/products/1', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn('Edit Product', resp.get_data(as_text=True))
+
+            # # test editting a product with seller_email not in the session
+            client.get('/logout')
+            resp = client.post('/products/1', follow_redirects=True, data={'product_name': 'Editted Name', 'product_price': '999.99', 'product_image': 'editted link', 'product_selling_status': 'Selling'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Editted Name', resp.get_data(as_text=True))
+            self.assertNotIn('999.99', resp.get_data(as_text=True))
+            self.assertNotIn('editted link', resp.get_data(as_text=True))
+
+            # test editting a product with seller_email in the session
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.post('/products/1', follow_redirects=True, data={'product_name': 'Editted Name', 'product_price': '999.99', 'product_image': 'editted link', 'product_selling_status': 'Selling'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn('Edit Product', resp.get_data(as_text=True))
+            self.assertIn('Editted Name', resp.get_data(as_text=True))
+            self.assertIn('999.99', resp.get_data(as_text=True))
+            self.assertIn('editted link', resp.get_data(as_text=True))


### PR DESCRIPTION
**What does this PR do?**
- This pull request allows sellers to edit product data

**Description of the task to be completed** 
- Click on a products row to go to a page with that product's information
- Show how the product information changes the product data's visual representation
- When sellers edit product information, update the visual representation

**How should this  be tested**
- (On Windows) Run `. venv/scripts/activate` 
- `python run.py`
- Go to http://127.0.0.1:5000/login
- Enter the correct email and password and submit them
- View the dashboard page
- Press the products button
- Fill out the "add products" form and submit it
- Click on the added product in the products table
- Edit the product data in the "Edit Products" section
- See the changes in the visual representation
- Go back to the products page and view the changes there.