### PR TITLE
Sellers can add and view sub-products

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 """Initializes the flask app."""
 from flask import Flask, render_template, redirect, session, request
 from forms import LoginForm
-from models import connect_db, Product, db
+from models import connect_db, Product, db, Subproduct
 from config import app_config
 import os
 
@@ -44,14 +44,12 @@ def products():
     if ("seller_email" not in session):
         return redirect('/login')
     products = Product.query.all()
-    print(products)
     return render_template('seller/products.html', products=products)
 
 @app.route('/products', methods=['POST'])
 def add_product():
     if ("seller_email" not in session):
         return redirect('/login')
-    print(request.form)
     new_product = Product(
         name=request.form['product_name'],
         price=float(request.form['product_price']),
@@ -68,7 +66,6 @@ def get_product(id):
     product = Product.query.get_or_404(id)
     return render_template('seller/product.html', prod = product)
 
-
 @app.route('/products/<id>', methods=['POST'])
 def update_product(id):
     if ("seller_email" not in session):
@@ -79,5 +76,26 @@ def update_product(id):
     product.image_url = request.form['product_image']
     product.category = request.form['product_selling_status']
     db.session.add(product)
+    db.session.commit()
+    return redirect(f'/products/{id}')
+
+@app.route('/products/<id>/delete', methods=['GET'])
+def delete_product(id):
+    if ("seller_email" not in session):
+        return redirect('/login')
+    product = Product.query.get(id)
+    db.session.delete(product)
+    db.session.commit()
+    return redirect('/products')
+@app.route('/products/<id>/subproducts', methods=['POST'])
+def add_subproduct(id):
+    if ("seller_email" not in session):
+        return redirect('/login')
+    new_subproduct = Subproduct(
+        product_id = id,
+        name = request.form['subproduct_name'],
+        image_url = request.form['subproduct_image']
+    )
+    db.session.add(new_subproduct)
     db.session.commit()
     return redirect(f'/products/{id}')

--- a/app/templates/seller/product.html
+++ b/app/templates/seller/product.html
@@ -18,13 +18,36 @@
                     <img src="{{prod.image_url}}" height="250" width="250">
                     </div>
                 </div>
+                <div class="col-sm-12 d-md-5 d-flex" style="overflow: auto;">
+                    {% for sub in prod.subproducts %}
+                    <div class="d-flex flex-column align-items-center">
+                        <img class="m-3" src="{{sub.image_url}}" height="130" width="130">
+                        <span class="mb-3 mx-3">{{sub.name}}</span>
+                    </div>
+                    {% endfor %}
+                </div>
                 <div class="col-12 d-flex justify-content-center">
                     <h3 class="mt-3">${{prod.price}}</h3><a class="mt-3 mx-3 btn btn-md btn-primary text-white" href="#">Buy</a>
                 </div>
             </div>
         </div>
+        <br>
+        <div class="m-3 mt-0 p-3 add-subproduct-container border rounded shadow-lg d-none d-lg-block">
+        <center><h2>Add a Subproduct</h2></center>
+        <form class="" action="/products/{{prod.id}}/subproducts" method="POST">
+            <div class="col-12">
+                    <label for="subproduct-name">Name</label>
+                    <input type="text" name="subproduct_name" class="form-control" id="subproduct-name" placeholder="Name" required>
+                    <br>
+                    <label for="subproduct-image">Image URL</label>
+                    <input type="text" name="subproduct_image" class="form-control" id="subproduct-image" placeholder="Image URL" required>
+                    <br>
+                    <button type="submit" class="btn btn-primary">Add</button>
+            </div>
+            </form>
+        </div>
     </div>
-    <div class="col-md-2 d-lg-none"></div>
+    <div class="col-md-2 d-lg-none"></div>    
     <div class="edit-product col-xs-12 col-sm-12 col-md-12 col-lg-6 col-xl-7">
         <div class="row">
             <div class="col-12 p-3 edit-product-container border rounded shadow-lg">
@@ -65,7 +88,28 @@
                 </div>
                 <br>
                 <button type="submit" class="btn btn-primary">Save</button>
+                <a href="/products/{{prod.id}}/delete" class="btn btn-danger mx-3">Delete</a>
             </form>
             </div>
+            <div class="m-3 p-3 add-subproduct-container border rounded shadow-lg d-block d-lg-none">
+                <center><h2>Add a Subproduct</h2></center>
+                <form class="mt-3" action="/products/{{prod.id}}/subproducts" method="POST">
+                    <div class="row">
+                    <div class="col-6 col-lg-12">
+                            <label for="subproduct-name">Name</label>
+                            <input type="text" name="subproduct_name" class="form-control" id="subproduct-name" placeholder="Name" required>
+                    </div>
+                    <br>
+                    <div class="col-6 col-lg-12">
+                            <label for="subproduct-image">Image URL</label>
+                            <input type="text" name="subproduct_image" class="form-control" id="subproduct-image" placeholder="Image URL" required>
+                            </div><br>
+                </div>
+                            <button type="submit" class="mt-3 btn btn-primary">Add</button>
+
+                    </form>
+                </div>
+        </div>
+    </div>
 </div>
 {% endblock %} 

--- a/app/templates/seller/products.html
+++ b/app/templates/seller/products.html
@@ -55,7 +55,7 @@
                     <td><img src="{{prod.image_url}}" class="prod-img"></img></td>
                     <td>{{prod.price}}</td>
                     <td>{{prod.category}}</td>
-                  </tr>
+                </tr>
               </tbody>
             {% endfor %}
             </table>

--- a/static/style.css
+++ b/static/style.css
@@ -106,7 +106,8 @@ body {
 }
 
 .edit-product-container,
-.view-product-container {
+.view-product-container,
+.add-subproduct-container {
 	display: flex-inline;
 	flex-direction: column;
 	align-items: center;

--- a/tests/test_seller_routes.py
+++ b/tests/test_seller_routes.py
@@ -10,7 +10,7 @@ class SellerRoutesTestCase(TestCase):
 
         # define some useful class variables
         self.product_data = {'product_name': 'Easter Kit', 'product_price': '5.99', 'product_image': 'https://scontent-ort2-2.xx.fbcdn.net/v/t1.0-9/165711988_218591189816105_7202222520073647668_o.jpg?_nc_cat=107&ccb=1-3&_nc_sid=730e14&_nc_ohc=THCcNKVPaEIAX9ltqbV&_nc_ht=scontent-ort2-2.xx&oh=85a30cd8715887c1d4e7111e499330e1&oe=6086013E', 'product_selling_status': 'Not Selling'}
-        
+        self.subproduct_data = {'subproduct_name': 'name', 'subproduct_image': 'image'}
 
 
     def test_login_and_logout(self):
@@ -92,7 +92,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertIn('Easter Kit', resp.get_data(as_text=True))
             self.assertIn('5.99', resp.get_data(as_text=True))
             self.assertIn('https://scontent-ort2-2.xx.fbcdn.net/v/t1.0-9/16571', resp.get_data(as_text=True))
-            self.assertIn('Not Selling', resp.get_data(as_text=True))  
+            self.assertIn('Not Selling', resp.get_data(as_text=True))
 
     def test_updating_products(self):
         with self.client as client:
@@ -101,18 +101,21 @@ class SellerRoutesTestCase(TestCase):
             resp = client.get('/products/1', follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
 
             # test going to a product page with seller_email in the session
             client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
             resp = client.get('/products/1', follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
             self.assertIn('Edit Product', resp.get_data(as_text=True))
+            self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
 
             # # test editting a product with seller_email not in the session
             client.get('/logout')
             resp = client.post('/products/1', follow_redirects=True, data={'product_name': 'Editted Name', 'product_price': '999.99', 'product_image': 'editted link', 'product_selling_status': 'Selling'})
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
             self.assertNotIn('Editted Name', resp.get_data(as_text=True))
             self.assertNotIn('999.99', resp.get_data(as_text=True))
             self.assertNotIn('editted link', resp.get_data(as_text=True))
@@ -122,6 +125,38 @@ class SellerRoutesTestCase(TestCase):
             resp = client.post('/products/1', follow_redirects=True, data={'product_name': 'Editted Name', 'product_price': '999.99', 'product_image': 'editted link', 'product_selling_status': 'Selling'})
             self.assertEqual(resp.status_code, 200)
             self.assertIn('Edit Product', resp.get_data(as_text=True))
+            self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
             self.assertIn('Editted Name', resp.get_data(as_text=True))
             self.assertIn('999.99', resp.get_data(as_text=True))
             self.assertIn('editted link', resp.get_data(as_text=True))
+
+            # test deleting a product with seller_email not in the session
+            client.get('/logout')
+            resp = client.get('/products/2/delete', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+
+            # test deleting a product with seller_email in the sesison
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.get('/products/2/delete', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn('Add a Product', resp.get_data(as_text=True))
+            self.assertIn('<h2>Products</h2>', resp.get_data(as_text=True))
+            resp = client.get('/products/2', follow_redirects=True)
+            self.assertNotEqual(resp.status_code, 200)
+
+            # test adding a subproduct with seller_email not in the session
+            client.post('/products', data=self.product_data)
+            client.get('/logout')
+            resp = client.post('/products/3/subproducts', data=self.subproduct_data, follow_redirects=True)
+            self.assertEqual(200, resp.status_code)
+            self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+
+            # test adding a subproduct with seller_email in the session
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.post('/products/3/subproducts', data=self.subproduct_data, follow_redirects=True)
+            self.assertEqual(200, resp.status_code)
+            self.assertIn('Edit Product', resp.get_data(as_text=True))
+            self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertIn(self.subproduct_data['subproduct_name'], resp.get_data(as_text=True))


### PR DESCRIPTION
**What does this PR do?**
- This pull request allows sellers to add and view subproducts

**Description of the task to be completed** 
- Fill out and submit an add subproducts form
- View the added subproduct data in the product visualization

**How should this  be tested**
- (On Windows) Run `. venv/scripts/activate` 
- `python run.py`
- Go to http://127.0.0.1:5000/login
- Enter the correct email and password and submit them
- View the dashboard page
- Press the products button
- Fill out the "add products" form and submit it
- Click on the added product in the products table
- Fill out the "add subproducts" form and submit it
- View the added subproduct information in the product visualization section