### PR TITLE
Sellers can delete subproducts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,7 +57,7 @@ def add_product():
         category=request.form["product_selling_status"])
     db.session.add(new_product)
     db.session.commit()
-    return redirect('/products') 
+    return redirect('/products')
 
 @app.route('/products/<id>', methods=['GET'])
 def get_product(id):
@@ -87,6 +87,7 @@ def delete_product(id):
     db.session.delete(product)
     db.session.commit()
     return redirect('/products')
+    
 @app.route('/products/<id>/subproducts', methods=['POST'])
 def add_subproduct(id):
     if ("seller_email" not in session):
@@ -97,5 +98,25 @@ def add_subproduct(id):
         image_url = request.form['subproduct_image']
     )
     db.session.add(new_subproduct)
+    db.session.commit()
+    return redirect(f'/products/{id}')
+
+@app.route('/products/<id>/subproducts/<sid>', methods=['POST'])
+def update_subproducts(id, sid):
+    if ("seller_email" not in session):
+        return redirect('/login')
+    subproduct = Subproduct.query.get(sid)
+    subproduct.name = request.form['subproduct_name']
+    subproduct.image_url = request.form['subproduct_image']
+    db.session.add(subproduct)
+    db.session.commit()
+    return redirect(f'/products/{id}')
+
+@app.route('/products/<id>/subproducts/<sid>/delete', methods=["GET"])
+def delete_subproduct(id, sid):
+    if ('seller_email' not in session):
+        return redirect('/login')
+    subproduct = Subproduct.query.get(sid)
+    db.session.delete(subproduct)
     db.session.commit()
     return redirect(f'/products/{id}')

--- a/app/templates/seller/product.html
+++ b/app/templates/seller/product.html
@@ -109,7 +109,26 @@
 
                     </form>
                 </div>
+            <div class="col-12 mb-3 p-3 edit-product-container border rounded shadow-lg">
+            <center><h2>Edit Subproducts</h2></center>
+            <div class="row">
+                {% for sub in prod.subproducts %}
+                <div class="col-6">
+                    <form class="mt-3" action="/products/{{prod.id}}/subproducts/{{sub.id}}" method="POST">
+                        <label for="subproduct-name">Name</label>
+                        <input type="text" name="subproduct_name" class="form-control" id="subproduct-name" value="{{sub.name}}" required>
+                        <br>
+                        <label for="subproduct-image">Image URL</label>
+                        <input type="text" name="subproduct_image" class="form-control" id="subproduct-image" value="{{sub.image_url}}" required>
+                        <br>
+                        <button type="submit" class="btn btn-primary">Save</button>
+                        <a class="btn btn-danger mx-3" href="/products/{{prod.id}}/subproducts/{{sub.id}}/delete">Delete</a>
+                    </form>
+                </div>
+                {% endfor %}
+            </div>
+            </div>
         </div>
     </div>
 </div>
-{% endblock %} 
+{% endblock %}  

--- a/app/templates/seller/products.html
+++ b/app/templates/seller/products.html
@@ -50,7 +50,7 @@
                   </thead>
             {% for prod in products %}
             <tbody>
-                  <tr class="table-row" data-id="{{prod.id}}">
+                  <tr class="table-row" data-id={{prod.id}}>
                     <td>{{prod.name}}</td>
                     <td><img src="{{prod.image_url}}" class="prod-img"></img></td>
                     <td>{{prod.price}}</td>

--- a/tests/test_seller_routes.py
+++ b/tests/test_seller_routes.py
@@ -92,7 +92,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertIn('Easter Kit', resp.get_data(as_text=True))
             self.assertIn('5.99', resp.get_data(as_text=True))
             self.assertIn('https://scontent-ort2-2.xx.fbcdn.net/v/t1.0-9/16571', resp.get_data(as_text=True))
-            self.assertIn('Not Selling', resp.get_data(as_text=True))
+            self.assertIn('Not Selling', resp.get_data(as_text=True)) 
 
     def test_updating_products(self):
         with self.client as client:
@@ -102,6 +102,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
             self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertNotIn('Edit Subproducts', resp.get_data(as_text=True))
 
             # test going to a product page with seller_email in the session
             client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
@@ -109,6 +110,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertIn('Edit Product', resp.get_data(as_text=True))
             self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertIn('Edit Subproducts', resp.get_data(as_text=True))
 
             # # test editting a product with seller_email not in the session
             client.get('/logout')
@@ -116,6 +118,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
             self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertNotIn('Edit Subproducts', resp.get_data(as_text=True))
             self.assertNotIn('Editted Name', resp.get_data(as_text=True))
             self.assertNotIn('999.99', resp.get_data(as_text=True))
             self.assertNotIn('editted link', resp.get_data(as_text=True))
@@ -126,6 +129,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertIn('Edit Product', resp.get_data(as_text=True))
             self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertIn('Edit Subproducts', resp.get_data(as_text=True))
             self.assertIn('Editted Name', resp.get_data(as_text=True))
             self.assertIn('999.99', resp.get_data(as_text=True))
             self.assertIn('editted link', resp.get_data(as_text=True))
@@ -135,6 +139,8 @@ class SellerRoutesTestCase(TestCase):
             resp = client.get('/products/2/delete', follow_redirects=True)
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertNotIn('Edit Subproducts', resp.get_data(as_text=True))
 
             # test deleting a product with seller_email in the sesison
             client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
@@ -152,6 +158,7 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(200, resp.status_code)
             self.assertNotIn('Edit Product', resp.get_data(as_text=True))
             self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertNotIn('Edit Subproducts', resp.get_data(as_text=True))
 
             # test adding a subproduct with seller_email in the session
             client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
@@ -159,4 +166,35 @@ class SellerRoutesTestCase(TestCase):
             self.assertEqual(200, resp.status_code)
             self.assertIn('Edit Product', resp.get_data(as_text=True))
             self.assertIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertIn('Edit Subproducts', resp.get_data(as_text=True))
             self.assertIn(self.subproduct_data['subproduct_name'], resp.get_data(as_text=True))
+
+            # test editting a subproduct with seller_email not in the session
+            client.get('/logout')
+            resp = client.post('/products/3/subproducts/5', follow_redirects=True, data={'subproduct_name': 'Editted Name', 'subproduct_image': 'Editted Link'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Editted Name', resp.get_data(as_text=True))
+            self.assertNotIn('Editted Link', resp.get_data(as_text=True))
+
+            # test editting a subproduct with seller_email in the session
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.post('/products/3/subproducts/5', follow_redirects=True, data={'subproduct_name': 'Editted Name', 'subproduct_image': 'Editted Link'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn('Editted Name', resp.get_data(as_text=True))
+            self.assertIn('Editted Link', resp.get_data(as_text=True))
+
+            # test deleting a subproduct with seller_email not in the session
+            client.get('/logout')
+            resp = client.get('/products/3/subproducts/5/delete', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Edit Product', resp.get_data(as_text=True))
+            self.assertNotIn('Add a Subproduct', resp.get_data(as_text=True))
+            self.assertNotIn('Edit Subproducts', resp.get_data(as_text=True))
+
+
+            # test deleting a subproduct with seller_email in the session
+            client.post('/login', data={'email':os.environ.get('seller_email'), 'password':os.environ.get('seller_password')})
+            resp = client.get('/products/3/subproducts/5/delete', follow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('Editted Name', resp.get_data(as_text=True))
+            self.assertNotIn('Editted Link', resp.get_data(as_text=True)) 


### PR DESCRIPTION
**What does this PR do?**
- This pull request allows sellers to delete subproducts

**Description of the task to be completed** 
- Add a delete button for each subproduct in the "edit subproduct" section
- When sellers delete a subproduct, update the product's visual representation

**How should this  be tested**
- (On Windows) Run `. venv/scripts/activate` 
- `python run.py`
- Go to http://127.0.0.1:5000/login
- Enter the correct email and password and submit them
- View the dashboard page
- Press the products button
- Fill out the "add products" form and submit it
- Click on the added product in the products table
- Add a subproduct
- Delete that subproduct and confirm it is no longer in the visual representation and is no longer in the "Edit Subproducts" section.